### PR TITLE
handle comment at end of line

### DIFF
--- a/ext/ios_parser/c_lexer/lexer.c
+++ b/ext/ios_parser/c_lexer/lexer.c
@@ -240,6 +240,17 @@ static void process_space(LexInfo *lex) {
 
 static void process_comment(LexInfo *lex) {
     char c = CURRENT_CHAR(lex);
+    int token_count = RARRAY_LEN(lex->tokens);
+    VALUE last_token, last_value;
+
+    if (0 < token_count) {
+      last_token = rb_ary_entry(lex->tokens, token_count - 1);
+      last_value = TOKEN_VALUE(last_token);
+
+      if (TYPE(last_value) != T_SYMBOL) {
+        ADD_TOKEN(lex, ID2SYM(rb_intern("EOL")));
+      }
+    }
 
     if (IS_NEWLINE(c)) {
         delimit(lex);

--- a/lib/ios_parser/lexer.rb
+++ b/lib/ios_parser/lexer.rb
@@ -80,7 +80,12 @@ module IOSParser
 
     def comment
       self.state = :comment
-      return unless newline?
+      tokens << make_token(:EOL) if tokens.last &&
+                                    !tokens.last.value.is_a?(Symbol)
+      comment_newline if newline?
+    end
+
+    def comment_newline
       delimit
       self.start_of_line = @this_char + 1
       self.state = :line_start

--- a/spec/lib/ios_parser/lexer_spec.rb
+++ b/spec/lib/ios_parser/lexer_spec.rb
@@ -193,7 +193,7 @@ END
 
       context 'comments' do
         let(:input) { 'ip addr 127.0.0.0.1 ! asdfsdf' }
-        let(:output) { ['ip', 'addr', '127.0.0.0.1'] }
+        let(:output) { ['ip', 'addr', '127.0.0.0.1', :EOL] }
         subject { klass.new.call(input).map(&:value) }
         it('dropped') { should == output }
       end
@@ -340,6 +340,22 @@ END
           expect(subject_pure).to eq expected_full
         end
       end
+
+      context 'comment at end of line' do
+        let(:input) do
+          <<-END.unindent
+            description !
+            switchport access vlan 2
+          END
+        end
+
+        let(:output) do
+          ['description', :EOL, 'switchport', 'access', 'vlan', 2, :EOL]
+        end
+
+        it { expect(subject_pure.map(&:value)).to eq output }
+        it { expect(subject.map(&:value)).to eq output }
+      end # context 'comment at end of line' do
     end
   end
 end

--- a/spec/lib/ios_parser_spec.rb
+++ b/spec/lib/ios_parser_spec.rb
@@ -99,5 +99,22 @@ describe IOSParser do
         expect(actual).to eq(output)
       end
     end # context "partial outdent" do
+
+    context 'comment at end of line' do
+      let(:input) do
+        <<END.unindent
+          description !
+          switchport access vlan 2
+END
+      end
+
+      subject { described_class.parse(input) }
+
+      it 'parses both commands' do
+        should be_a IOSParser::IOS::Document
+        expect(subject.find(starts_with: 'description')).not_to be_nil
+        expect(subject.find(starts_with: 'switchport')).not_to be_nil
+      end
+    end
   end # describe '.parse'
 end # describe IOSParser


### PR DESCRIPTION
Unconditionally add an EOL token when a comment appears after a non-whitespace
token. Otherwise, the the newline will be discarded when the comment is
processed.