### PR TITLE
C-lexer: Parse larger integers

### DIFF
--- a/ext/ios_parser/c_lexer/lexer.c
+++ b/ext/ios_parser/c_lexer/lexer.c
@@ -154,7 +154,7 @@ static void delimit(LexInfo *lex) {
     case (LEX_STATE_INTEGER):
         strncpy(string, &lex->text[lex->token_start], lex->token_length);
         string[lex->token_length] = '\0';
-        token = rb_int_new(atoi(string));
+        token = rb_int_new(atoll(string));
         break;
 
     case (LEX_STATE_DECIMAL):

--- a/spec/lib/ios_parser/lexer_spec.rb
+++ b/spec/lib/ios_parser/lexer_spec.rb
@@ -379,6 +379,19 @@ END
         it { expect(subject_pure.map(&:value)).to eq output }
         it { expect(subject.map(&:value)).to eq output }
       end # context 'comment at end of line' do
+
+      context 'large integers up to 2^63-1' do
+        let(:input) do
+          "42 4200000000 9223372036854775807"
+        end
+
+        let(:output) do
+          [42, 4200000000, 9223372036854775807]
+        end
+
+        it { expect(subject_pure.map(&:value)).to eq output }
+        it { expect(subject.map(&:value)).to eq output }
+      end # context 'large integers up to 2^63-1' do
     end
   end
 end


### PR DESCRIPTION
In the C-lexer, integers were parsed to a signed int which overflowed at
2^31-1. We change this to long-long which overflows at 2^63-1.  The
c-based lexer is sill less flexible than the ruby lexer, which is able
to handle larger numbers, but this change is a big improvement without
complicating the parser.