### PR TITLE
Fix compilation error in the C extension

### DIFF
--- a/ext/ios_parser/c_lexer/lexer.c
+++ b/ext/ios_parser/c_lexer/lexer.c
@@ -201,7 +201,7 @@ static VALUE allocate(VALUE klass) {
     return Data_Wrap_Struct(klass, mark, deallocate, lex);
 }
 
-static VALUE initialize(VALUE self, VALUE input_text) {
+static VALUE initialize(VALUE self) {
     LexInfo *lex;
     Data_Get_Struct(self, LexInfo, lex);
 

--- a/lib/ios_parser/version.rb
+++ b/lib/ios_parser/version.rb
@@ -1,7 +1,7 @@
 module IOSParser
   class << self
     def version
-      '0.9.0'
+      '0.10.0'
     end
   end
 end


### PR DESCRIPTION
lexer.new is called without arguments, and is defined with a stated arity of zero in the C code:

    rb_define_method(rb_cCLexer, "initialize", initialize, 0);

On this basis, the function signature appears to be incorrect.  Removing the superfluous parameter fixes a build error that prevented this gem from being built on recent build environments.